### PR TITLE
Publish temp to LiveView

### DIFF
--- a/lib/sprinkler_web/live/temperature_live.ex
+++ b/lib/sprinkler_web/live/temperature_live.ex
@@ -9,7 +9,7 @@ defmodule SprinklerWeb.TemperatureLive do
     {:ok, assign(socket, temp: "Unknown")}
   end
 
-  def handle_info(%{topic: @telemetry, temp: payload}, socket) do
-    {:noreply, assign(socket, temp: payload)}
+  def handle_info(%{topic: @telemetry, event: "new_reading", payload: %{temp: temp}}, socket) do
+    {:noreply, assign(socket, temp: temp)}
   end
 end

--- a/lib/sprinkler_web/live/temperature_live.ex
+++ b/lib/sprinkler_web/live/temperature_live.ex
@@ -6,13 +6,13 @@ defmodule SprinklerWeb.TemperatureLive do
   def mount(_params, _session, socket) do
     Phoenix.PubSub.subscribe(Sprinkler.PubSub, @telemetry_topic)
 
-    {:ok, assign(socket, temp: "Unknown")}
+    {:ok, assign(socket, tmp: "Unknown")}
   end
 
   def handle_info(
-        %{topic: @telemetry_topic, event: "new_reading", payload: %{temp: temp}},
+        %{topic: @telemetry_topic, event: "new_reading", payload: %{tmp: tmp}},
         socket
       ) do
-    {:noreply, assign(socket, temp: temp)}
+    {:noreply, assign(socket, tmp: tmp)}
   end
 end

--- a/lib/sprinkler_web/live/temperature_live.ex
+++ b/lib/sprinkler_web/live/temperature_live.ex
@@ -1,0 +1,15 @@
+defmodule SprinklerWeb.TemperatureLive do
+  use Phoenix.LiveView
+
+  @telemetry "telemetry"
+
+  def mount(_params, _session, socket) do
+    Phoenix.PubSub.subscribe(Sprinkler.PubSub, @telemetry)
+
+    {:ok, assign(socket, temp: "Unknown")}
+  end
+
+  def handle_info(%{topic: @telemetry, temp: payload}, socket) do
+    {:noreply, assign(socket, temp: payload)}
+  end
+end

--- a/lib/sprinkler_web/live/temperature_live.ex
+++ b/lib/sprinkler_web/live/temperature_live.ex
@@ -1,15 +1,18 @@
 defmodule SprinklerWeb.TemperatureLive do
   use Phoenix.LiveView
 
-  @telemetry "telemetry"
+  @telemetry_topic "telemetry"
 
   def mount(_params, _session, socket) do
-    Phoenix.PubSub.subscribe(Sprinkler.PubSub, @telemetry)
+    Phoenix.PubSub.subscribe(Sprinkler.PubSub, @telemetry_topic)
 
     {:ok, assign(socket, temp: "Unknown")}
   end
 
-  def handle_info(%{topic: @telemetry, event: "new_reading", payload: %{temp: temp}}, socket) do
+  def handle_info(
+        %{topic: @telemetry_topic, event: "new_reading", payload: %{temp: temp}},
+        socket
+      ) do
     {:noreply, assign(socket, temp: temp)}
   end
 end

--- a/lib/sprinkler_web/live/temperature_live.html.leex
+++ b/lib/sprinkler_web/live/temperature_live.html.leex
@@ -1,2 +1,2 @@
 <h1> Hello! </h1>
-Temp is: <%= @temp %>
+Temp is: <%= @tmp %>

--- a/lib/sprinkler_web/live/temperature_live.html.leex
+++ b/lib/sprinkler_web/live/temperature_live.html.leex
@@ -1,0 +1,2 @@
+<h1> Hello! </h1>
+Temp is: <%= @temp %>

--- a/lib/sprinkler_web/mqtt/handler.ex
+++ b/lib/sprinkler_web/mqtt/handler.ex
@@ -3,6 +3,8 @@ defmodule SprinklerWeb.Mqtt.Handler do
 
   use Tortoise.Handler
 
+  @telemetry "telemetry"
+
   def init(args) do
     {:ok, args}
   end
@@ -15,10 +17,10 @@ defmodule SprinklerWeb.Mqtt.Handler do
     {:ok, state}
   end
 
-  def handle_message(["rs", _client_id, "telemetry"], _payload, state) do
+  def handle_message(["rs", _client_id, "telemetry"], payload, state) do
     # What should we do with sensor information?
-    # IO.inspect(client_id)
-    # IO.inspect(payload)
+    # In which format are we receiving the temp? Might have to change this later.
+    Phoenix.PubSub.broadcast(Sprinkler.PubSub, @telemetry, %{topic: @telemetry, temp: payload})
 
     {:ok, state}
   end

--- a/lib/sprinkler_web/mqtt/handler.ex
+++ b/lib/sprinkler_web/mqtt/handler.ex
@@ -3,7 +3,7 @@ defmodule SprinklerWeb.Mqtt.Handler do
 
   use Tortoise.Handler
 
-  @telemetry "telemetry"
+  @telemetry_topic "telemetry"
 
   def init(args) do
     {:ok, args}
@@ -20,7 +20,7 @@ defmodule SprinklerWeb.Mqtt.Handler do
   def handle_message(["rs", _client_id, "telemetry"], payload, state) do
     # What should we do with sensor information?
     # In which format are we receiving the temp? Might have to change this later.
-    SprinklerWeb.Endpoint.broadcast(@telemetry, "new_reading", %{temp: payload})
+    SprinklerWeb.Endpoint.broadcast(@telemetry_topic, "new_reading", %{temp: payload})
     {:ok, state}
   end
 

--- a/lib/sprinkler_web/mqtt/handler.ex
+++ b/lib/sprinkler_web/mqtt/handler.ex
@@ -20,7 +20,7 @@ defmodule SprinklerWeb.Mqtt.Handler do
   def handle_message(["rs", _client_id, "telemetry"], payload, state) do
     # What should we do with sensor information?
     # In which format are we receiving the temp? Might have to change this later.
-    SprinklerWeb.Endpoint.broadcast(@telemetry_topic, "new_reading", %{temp: payload})
+    SprinklerWeb.Endpoint.broadcast(@telemetry_topic, "new_reading", %{tmp: payload})
     {:ok, state}
   end
 

--- a/lib/sprinkler_web/mqtt/handler.ex
+++ b/lib/sprinkler_web/mqtt/handler.ex
@@ -20,8 +20,7 @@ defmodule SprinklerWeb.Mqtt.Handler do
   def handle_message(["rs", _client_id, "telemetry"], payload, state) do
     # What should we do with sensor information?
     # In which format are we receiving the temp? Might have to change this later.
-    Phoenix.PubSub.broadcast(Sprinkler.PubSub, @telemetry, %{topic: @telemetry, temp: payload})
-
+    SprinklerWeb.Endpoint.broadcast(@telemetry, "new_reading", %{temp: payload})
     {:ok, state}
   end
 

--- a/lib/sprinkler_web/router.ex
+++ b/lib/sprinkler_web/router.ex
@@ -84,5 +84,6 @@ defmodule SprinklerWeb.Router do
     get "/users/confirm", UserConfirmationController, :new
     post "/users/confirm", UserConfirmationController, :create
     get "/users/confirm/:token", UserConfirmationController, :confirm
+    live "/temperature", TemperatureLive
   end
 end

--- a/test/sprinkler_web/live/temperature_live_test.exs
+++ b/test/sprinkler_web/live/temperature_live_test.exs
@@ -9,7 +9,7 @@ defmodule SprinklerWeb.TemperatureLiveTest do
     {:ok, page_live, disconnected_html} = live(conn, "/temperature")
     assert disconnected_html =~ "Unknown"
     assert render(page_live) =~ "Unknown"
-    send(page_live.pid, %{topic: @telemetry, temp: "25"})
+    send(page_live.pid, %{topic: @telemetry, event: "new_reading", payload: %{temp: "25"}})
     assert render(page_live) =~ "Temp is: 25"
   end
 end

--- a/test/sprinkler_web/live/temperature_live_test.exs
+++ b/test/sprinkler_web/live/temperature_live_test.exs
@@ -1,0 +1,15 @@
+defmodule SprinklerWeb.TemperatureLiveTest do
+  use SprinklerWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  @telemetry "telemetry"
+
+  test "handle_info/2 when temp is received", %{conn: conn} do
+    {:ok, page_live, disconnected_html} = live(conn, "/temperature")
+    assert disconnected_html =~ "Unknown"
+    assert render(page_live) =~ "Unknown"
+    send(page_live.pid, %{topic: @telemetry, temp: "25"})
+    assert render(page_live) =~ "Temp is: 25"
+  end
+end

--- a/test/sprinkler_web/live/temperature_live_test.exs
+++ b/test/sprinkler_web/live/temperature_live_test.exs
@@ -9,7 +9,7 @@ defmodule SprinklerWeb.TemperatureLiveTest do
     {:ok, page_live, disconnected_html} = live(conn, "/temperature")
     assert disconnected_html =~ "Unknown"
     assert render(page_live) =~ "Unknown"
-    send(page_live.pid, %{topic: @telemetry_topic, event: "new_reading", payload: %{temp: "25"}})
+    send(page_live.pid, %{topic: @telemetry_topic, event: "new_reading", payload: %{tmp: "25"}})
     assert render(page_live) =~ "Temp is: 25"
   end
 end

--- a/test/sprinkler_web/live/temperature_live_test.exs
+++ b/test/sprinkler_web/live/temperature_live_test.exs
@@ -3,13 +3,13 @@ defmodule SprinklerWeb.TemperatureLiveTest do
 
   import Phoenix.LiveViewTest
 
-  @telemetry "telemetry"
+  @telemetry_topic "telemetry"
 
   test "handle_info/2 when temp is received", %{conn: conn} do
     {:ok, page_live, disconnected_html} = live(conn, "/temperature")
     assert disconnected_html =~ "Unknown"
     assert render(page_live) =~ "Unknown"
-    send(page_live.pid, %{topic: @telemetry, event: "new_reading", payload: %{temp: "25"}})
+    send(page_live.pid, %{topic: @telemetry_topic, event: "new_reading", payload: %{temp: "25"}})
     assert render(page_live) =~ "Temp is: 25"
   end
 end

--- a/test/sprinkler_web/mqtt/handler_test.exs
+++ b/test/sprinkler_web/mqtt/handler_test.exs
@@ -1,7 +1,7 @@
 defmodule SprinklerWeb.Mqtt.HandlerTest do
   use ExUnit.Case, async: true
 
-  @telemetry "telemetry"
+  @telemetry_topic "telemetry"
 
   describe "handler methods" do
     alias SprinklerWeb.Mqtt.Handler
@@ -28,9 +28,9 @@ defmodule SprinklerWeb.Mqtt.HandlerTest do
     end
 
     test "handle_message/3 when telemetry is received" do
-      Phoenix.PubSub.subscribe(Sprinkler.PubSub, @telemetry)
+      Phoenix.PubSub.subscribe(Sprinkler.PubSub, @telemetry_topic)
       Handler.handle_message(["rs", "Arduino", "telemetry"], "25", [])
-      assert_receive %{topic: @telemetry, event: "new_reading", payload: %{temp: "25"}}
+      assert_receive %{topic: @telemetry_topic, event: "new_reading", payload: %{temp: "25"}}
     end
   end
 end

--- a/test/sprinkler_web/mqtt/handler_test.exs
+++ b/test/sprinkler_web/mqtt/handler_test.exs
@@ -1,6 +1,8 @@
 defmodule SprinklerWeb.Mqtt.HandlerTest do
   use ExUnit.Case, async: true
 
+  @telemetry "telemetry"
+
   describe "handler methods" do
     alias SprinklerWeb.Mqtt.Handler
 
@@ -23,6 +25,12 @@ defmodule SprinklerWeb.Mqtt.HandlerTest do
 
     test "terminate/2 returns ok" do
       assert Handler.terminate("termination is imminent", []) == :ok
+    end
+
+    test "handle_message/3 when telemetry is received" do
+      Phoenix.PubSub.subscribe(Sprinkler.PubSub, @telemetry)
+      Handler.handle_message(["rs", "Arduino", "telemetry"], "25", [])
+      assert_receive %{topic: @telemetry, event: "new_reading", payload: %{temp: "25"}}
     end
   end
 end

--- a/test/sprinkler_web/mqtt/handler_test.exs
+++ b/test/sprinkler_web/mqtt/handler_test.exs
@@ -30,7 +30,7 @@ defmodule SprinklerWeb.Mqtt.HandlerTest do
     test "handle_message/3 when telemetry is received" do
       Phoenix.PubSub.subscribe(Sprinkler.PubSub, @telemetry_topic)
       Handler.handle_message(["rs", "Arduino", "telemetry"], "25", [])
-      assert_receive %{topic: @telemetry_topic, event: "new_reading", payload: %{temp: "25"}}
+      assert_receive %{topic: @telemetry_topic, event: "new_reading", payload: %{tmp: "25"}}
     end
   end
 end


### PR DESCRIPTION
Now the handler publishes whatever it receives on the MQTTtopic, to an internal `PubSub` topic. 
Also, added a live view that shows anything that is published on that internal topic. 

We should decide format of messages that will be on the topic, and things that will actually be published in order to continue. 